### PR TITLE
Slow down AJAX request frequency by adding a timeout.

### DIFF
--- a/lib/ajax-chosen.js
+++ b/lib/ajax-chosen.js
@@ -10,12 +10,18 @@
         if (val.length < 3 || val === $(this).data('prevVal')) {
           return false;
         }
+        
+        // Stop previous ajax-request
+        if (this.timer) {
+            clearTimeout(this.timer);
+        }
+
         $(this).data('prevVal', val);
         field = $(this);
         options.data = {
           term: val
         };
-                if (typeof success !== "undefined" && success !== null) {
+        if (typeof success !== "undefined" && success !== null) {
           success;
         } else {
           success = options.success;
@@ -40,7 +46,10 @@
             return success();
           }
         };
-        return $.ajax(options);
+        
+        this.timer = setTimeout(function () {
+          return $.ajax(options);
+        }, 800);
       });
     };
   })(jQuery);


### PR DESCRIPTION
As requested in issue #3 (and because I needed it to not fire off so many AJAX requests at once), I've added a timeout of about a second between hitting $.ajax() again. This would be best as a configurable option that could be passed through to .ajaxChosen().
