### PR TITLE
chosen_xhr + allow data

### DIFF
--- a/lib/ajax-chosen.js
+++ b/lib/ajax-chosen.js
@@ -1,6 +1,7 @@
 (function() {
 
   (function($) {
+  	var chosen_xhr;
     return $.fn.ajaxChosen = function(options, callback) {
       var select;
       select = this;
@@ -12,9 +13,7 @@
         if (this.timer) clearTimeout(this.timer);
         $(this).data('prevVal', val);
         field = $(this);
-        options.data = {
-          term: val
-        };
+        options.data.term = val;
         if (typeof success === "undefined" || success === null) {
           success = options.success;
         }
@@ -33,7 +32,9 @@
           if (typeof success !== "undefined" && success !== null) return success();
         };
         return this.timer = setTimeout(function() {
-          return $.ajax(options);
+        	if (chosen_xhr) chosen_xhr.abort();
+			chosen_xhr = $.ajax(options);
+			return chosen_xhr;
         }, 800);
       });
       return this.next('.chzn-container').find(".chzn-search > input").bind('keyup', function() {
@@ -62,7 +63,9 @@
           if (typeof success !== "undefined" && success !== null) return success();
         };
         return this.timer = setTimeout(function() {
-          return $.ajax(options);
+        	if (chosen_xhr) chosen_xhr.abort();
+			chosen_xhr = $.ajax(options);
+			return chosen_xhr;
         }, 800);
       });
     };


### PR DESCRIPTION
Uses chosen_xhr to abort a request if a new one is made (stops results going kaput), and allow extra data in the data option
