### PR TITLE
A few fixes.

### DIFF
--- a/lib/ajax-chosen.js
+++ b/lib/ajax-chosen.js
@@ -15,6 +15,7 @@
         if (this.timer) {
           clearTimeout(this.timer);
         }
+        select.next('.chzn-container').find('.no-results').text("Looking for '" + val + "'");
         $(this).data('prevVal', val);
         field = $(this);
         options.data = {

--- a/src/ajax-chosen.coffee
+++ b/src/ajax-chosen.coffee
@@ -35,6 +35,9 @@
         # We delay searches by a small amount so that we don't flood the
         # server with ajax requests.
         clearTimeout(@timer) if @timer
+
+        # Modify no results message to be more meaningful
+        select.next('.chzn-container').find('.no-results').text("Looking for '" + val + "'")
         
         # Set the current search term so we don't execute the ajax call if
         # the user hits a key that isn't an input letter/number/symbol


### PR DESCRIPTION
1) Adding two options with default values
  minTermLength: minimum character length at which to send ajax (default: 3)
  afterTypeDelay: delay in milliseconds before calling ajax (default: 800)

2) Fixing weird input field resize.
  listzt:update causes the input field to be reset as is mentioned in the code.  However,
  Chosen calls search_field_scale while the input value is still empty, which causes the width
  of the input field to be the minimum 25px wide.  This was fixed by resetting the width to
  "auto" after Chosen sets it in search_field_scale

3) Don't make ajax call for control characters
  Ignore left/right command and ignore shift keyup.

4) Don't show option in drop down if it is already selected.
  In keeping in line with Chosen's functionality, if an option is selected in the multi select it
  should not appear as an available drop down suggestion.
