### PR TITLE
Adding fix for weird input width resize bug.

### DIFF
--- a/lib/ajax-chosen.js
+++ b/lib/ajax-chosen.js
@@ -1,84 +1,110 @@
-
-(function($) {
-  if ($ == null) $ = jQuery;
-  return $.fn.ajaxChosen = function(settings, callback) {
-    var chosenXhr, defaultOptions, options, select;
-    if (settings == null) settings = {};
-    if (callback == null) callback = function() {};
-    defaultOptions = {
-      minTermLength: 3,
-      afterTypeDelay: 500,
-      jsonTermKey: "term"
+(function() {
+  (function($) {
+    if ($ == null) {
+      $ = jQuery;
+    }
+    return $.fn.ajaxChosen = function(settings, callback) {
+      var chosenXhr, defaultOptions, options, select;
+      if (settings == null) {
+        settings = {};
+      }
+      if (callback == null) {
+        callback = function() {};
+      }
+      defaultOptions = {
+        minTermLength: 3,
+        afterTypeDelay: 500,
+        jsonTermKey: "term"
+      };
+      select = this;
+      chosenXhr = null;
+      options = $.extend({}, defaultOptions, settings);
+      this.chosen();
+      this.next('.chzn-container').find(".search-field > input").bind('keyup', function() {
+        var field, msg, val;
+        val = $.trim($(this).attr('value'));
+        msg = val.length < options.minTermLength ? "Keep typing..." : "Looking for '" + val + "'";
+        select.next('.chzn-container').find('.no-results').text(msg);
+        if (val.length < options.minTermLength || val === $(this).data('prevVal')) {
+          return false;
+        }
+        if (this.timer) {
+          clearTimeout(this.timer);
+        }
+        $(this).data('prevVal', val);
+        field = $(this);
+        if (!(options.data != null)) {
+          options.data = {};
+        }
+        options.data[options.jsonTermKey] = val;
+        if (typeof success === "undefined" || success === null) {
+          success = options.success;
+        }
+        options.success = function(data) {
+          var items;
+          if (!(data != null)) {
+            return;
+          }
+          select.find('option').each(function() {
+            if (!$(this).is(":selected")) {
+              return $(this).remove();
+            }
+          });
+          items = callback(data);
+          $.each(items, function(value, text) {
+            return $("<option />").attr('value', value).html(text).appendTo(select);
+          });
+          select.trigger("liszt:updated");
+          if (typeof success !== "undefined" && success !== null) {
+            success();
+          }
+          field.attr('value', val);
+          return field.css('width', 'auto');
+        };
+        return this.timer = setTimeout(function() {
+          if (chosenXhr) {
+            chosenXhr.abort();
+          }
+          return chosenXhr = $.ajax(options);
+        }, options.afterTypeDelay);
+      });
+      return this.next('.chzn-container').find(".chzn-search > input").bind('keyup', function() {
+        var field, val;
+        val = $.trim($(this).attr('value'));
+        if (val.length < options.minTermLength || val === $(this).data('prevVal')) {
+          return false;
+        }
+        field = $(this);
+        options.data = {};
+        options.data[options.jsonTermKey] = val;
+        if (typeof success === "undefined" || success === null) {
+          success = options.success;
+        }
+        options.success = function(data) {
+          var items;
+          if (!(data != null)) {
+            return;
+          }
+          select.find('option').each(function() {
+            return $(this).remove();
+          });
+          items = callback(data);
+          $.each(items, function(value, text) {
+            return $("<option />").attr('value', value).html(text).appendTo(select);
+          });
+          select.trigger("liszt:updated");
+          field.attr('value', val);
+          if (typeof success !== "undefined" && success !== null) {
+            return success();
+          }
+        };
+        return this.timer = setTimeout(function() {
+          if (chosenXhr) {
+            chosenXhr.abort();
+          }
+          return chosenXhr = $.ajax(options);
+        }, options.afterTypeDelay);
+      });
     };
-    select = this;
-    chosenXhr = null;
-    options = $.extend({}, defaultOptions, settings);
-    this.chosen();
-    this.next('.chzn-container').find(".search-field > input").bind('keyup', function() {
-      var field, msg, val;
-      val = $.trim($(this).attr('value'));
-      msg = val.length < options.minTermLength ? "Keep typing..." : "Looking for '" + val + "'";
-      select.next('.chzn-container').find('.no-results').text(msg);
-      if (val.length < options.minTermLength || val === $(this).data('prevVal')) {
-        return false;
-      }
-      if (this.timer) clearTimeout(this.timer);
-      $(this).data('prevVal', val);
-      field = $(this);
-      if (!(options.data != null)) options.data = {};
-      options.data[options.jsonTermKey] = val;
-      if (typeof success === "undefined" || success === null) {
-        success = options.success;
-      }
-      options.success = function(data) {
-        var items;
-        if (!(data != null)) return;
-        select.find('option').each(function() {
-          if (!$(this).is(":selected")) return $(this).remove();
-        });
-        items = callback(data);
-        $.each(items, function(value, text) {
-          return $("<option />").attr('value', value).html(text).appendTo(select);
-        });
-        select.trigger("liszt:updated");
-        if (typeof success !== "undefined" && success !== null) success();
-        return field.attr('value', val);
-      };
-      return this.timer = setTimeout(function() {
-        if (chosenXhr) chosenXhr.abort();
-        return chosenXhr = $.ajax(options);
-      }, options.afterTypeDelay);
-    });
-    return this.next('.chzn-container').find(".chzn-search > input").bind('keyup', function() {
-      var field, val;
-      val = $.trim($(this).attr('value'));
-      if (val.length < options.minTermLength || val === $(this).data('prevVal')) {
-        return false;
-      }
-      field = $(this);
-      options.data = {};
-      options.data[options.jsonTermKey] = val;
-      if (typeof success === "undefined" || success === null) {
-        success = options.success;
-      }
-      options.success = function(data) {
-        var items;
-        if (!(data != null)) return;
-        select.find('option').each(function() {
-          return $(this).remove();
-        });
-        items = callback(data);
-        $.each(items, function(value, text) {
-          return $("<option />").attr('value', value).html(text).appendTo(select);
-        });
-        select.trigger("liszt:updated");
-        field.attr('value', val);
-        if (typeof success !== "undefined" && success !== null) return success();
-      };
-      return this.timer = setTimeout(function() {
-        if (chosenXhr) chosenXhr.abort();
-        return chosenXhr = $.ajax(options);
-      }, options.afterTypeDelay);
-    });
-  };
-})($);
+  })($);
+}).call(this);

--- a/src/ajax-chosen.coffee
+++ b/src/ajax-chosen.coffee
@@ -91,7 +91,19 @@ do ($ = jQuery) ->
           # searches impossible), so we add the value the user was typing back into
           # the input field.
           field.attr('value', val)
-          
+
+          # Because non-ajax Chosen isn't constantly re-building results, when it
+          # DOES rebuild results (during liszt:updated above, it clears the input 
+          # search field before scaling it.  This causes the input field width to be 
+          # at it's minimum, which is about 25px.  
+
+          # The proper way to fix this would be create a new method in chosen for
+          # rebuilding results without clearing the input field.  Or to call 
+          # Chosen.search_field_scale() after resetting the value above.  This isn't
+          # possible with the current state of Chosen.  The quick fix is to simply reset
+          # the width of the field after we reset the value of the input text.
+          field.css('width','auto')
+                    
         # Execute the ajax call to search for autocomplete data with a timer
         @timer = setTimeout -> 
           chosenXhr.abort() if chosenXhr


### PR DESCRIPTION
Because non-ajax Chosen isn't constantly re-building results, when it
DOES rebuild results (during liszt:updated above, it clears the input 
search field before scaling it.  This causes the input field width to be 
at it's minimum, which is about 25px.  

The proper way to fix this would be create a new method in chosen for
rebuilding results without clearing the input field.  Or to call 
Chosen.search_field_scale() after resetting the value above.  This isn't
possible with the current state of Chosen.  The quick fix is to simply reset
the width of the field after we reset the value of the input text.
