### PR TITLE
Rearranging logic to deal with timing bugs.

### DIFF
--- a/src/ajax-chosen.coffee
+++ b/src/ajax-chosen.coffee
@@ -30,21 +30,29 @@ do ($ = jQuery) ->
         # Retrieve the current value of the input form
         val = $.trim $(@).attr('value')
 
+        # Depending on how much text the user has typed, let them know
+        # if they need to keep typing or if we are looking for their data
         msg = if val.length < options.minTermLength then "Keep typing..." else "Looking for '" + val + "'"
         select.next('.chzn-container').find('.no-results').text(msg)
         
-        # Some simple validation so we don't make excess ajax calls. I am
-        # assuming you don't want to perform a search with less than 3
-        # characters.
-        return false if val.length < options.minTermLength or val is $(@).data('prevVal')
+        # If input text has not changed ... do nothing
+        return false if val is $(@).data('prevVal')
+
+        # Set the current search term so we don't execute the ajax call if
+        # the user hits a key that isn't an input letter/number/symbol
+        $(@).data('prevVal', val)
         
+        # At this point, we have a new term/query ... the old timer
+        # is no longer valid.  Clear it.
+
         # We delay searches by a small amount so that we don't flood the
         # server with ajax requests.
         clearTimeout(@timer) if @timer
         
-        # Set the current search term so we don't execute the ajax call if
-        # the user hits a key that isn't an input letter/number/symbol
-        $(@).data('prevVal', val)
+        # Some simple validation so we don't make excess ajax calls. I am
+        # assuming you don't want to perform a search with less than 3
+        # characters.
+        return false if val.length < options.minTermLength
         
         # This is a useful reference for later
         field = $(@)


### PR DESCRIPTION
Previously there was a bug that could be reproduced by typing
something very quickly, selecting all of the text and then deleting it.
A few moments later, the previous value would magically re-appear in the
text box.

This occured, because we were checking for minTermLength before
clearing the timer.  So the function was returning false b/c of query
length before the timer could be cleared.

Theoretically if the input text value has changed from prevValue, the
previous query request is invalid, so it should be cleared.  I moved
this logic nearer to the top of the function and checked for the minTermLength
further down, after the timer has already been cleared.
