### PR TITLE
fix for issue #32 https://github.com/meltingice/ajax-chosen/issues/32

### DIFF
--- a/lib/ajax-chosen.js
+++ b/lib/ajax-chosen.js
@@ -57,9 +57,9 @@
             }
           });
           items = callback(data);
-          $.each(items, function(value, text) {
-            if ($.inArray(value + "-" + text, selected_values) === -1) {
-              return $("<option />").attr('value', value).html(text).appendTo(select);
+          $.each(items, function(key, item) {
+            if ($.inArray(item.value + "-" + item.text, selected_values) === -1) {
+              return $("<option />").attr('value', item.value).html(item.text).appendTo(select);
             }
           });
           select.trigger("liszt:updated");


### PR DESCRIPTION
Don't use the json array keys to hold the <option values>, this will cause unwanted ordering when using a numeric value as <option value"">

solution, define your json data like this:

[{"value":"277","text":"Feyenoord"},{"value":"10419","text":"Ajax"}]
