### PR TITLE
Don't trim typed input so that user's typing is not disrupted

### DIFF
--- a/src/ajax-chosen.coffee
+++ b/src/ajax-chosen.coffee
@@ -29,6 +29,7 @@ do ($ = jQuery) ->
           # into the input form that chosen has created
           
           # Retrieve the current value of the input form
+          untrimmed_val = $(@).attr('value')
           val = $.trim $(@).attr('value')
 
           # Depending on how much text the user has typed, let them know
@@ -107,7 +108,7 @@ do ($ = jQuery) ->
             # call trigger above. Often, this can be very annoying (and can make some
             # searches impossible), so we add the value the user was typing back into
             # the input field.
-            field.attr('value', val)
+            field.attr('value', untrimmed_val)
 
             # Because non-ajax Chosen isn't constantly re-building results, when it
             # DOES rebuild results (during liszt:updated above, it clears the input 


### PR DESCRIPTION
If the user types 'foo ' with a space, and the ajax call comes back
successfully, it replaces the 'foo ' with 'foo' (trimmed).

This causes inconsistent user experience as the user may have simply
paused while typing a space, and the space is then removed, mangling
his input. Note that this fix simply avoids trimming the user's visual
input, while still sending a trimmed value to the server.
