### PR TITLE
[FIX] invalid jquery ajax method description

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ There are some additional ajax-chosen specific options you can pass into the fir
 
 ``` js
 $("#example-input").ajaxChosen({
-	method: 'GET',
+	type: 'GET',
 	url: '/ajax-chosen/data.php',
 	dataType: 'json'
 }, function (data) {

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
 	<script type="text/javascript">
 	$(document).ready(function () {
 		$("#example1,#example2,#example3").ajaxChosen({
-			method: 'GET',
+			type: 'GET',
 			url: '/ajax-chosen/data.php',
 			dataType: 'json'
 		}, function (data) {


### PR DESCRIPTION
according to 
http://api.jquery.com/jQuery.ajax/
ajax method is set with option 'type' , not 'method'
fixed in descriptions
