### PR TITLE
Fix IE7 and IE8 compatibility

### DIFF
--- a/lib/ajax-chosen.js
+++ b/lib/ajax-chosen.js
@@ -50,7 +50,7 @@
         }
         success = options.success;
         options.success = function(data) {
-          var items, selected_values;
+          var items, nbItems, selected_values;
           if (!(data != null)) {
             return;
           }
@@ -66,8 +66,10 @@
             return $(this).remove();
           });
           items = callback(data);
+          nbItems = 0;
           $.each(items, function(i, element) {
             var group, text, value;
+            nbItems++;
             if (element.group) {
               group = select.find("optgroup[label='" + element.text + "']");
               if (!group.size()) {
@@ -100,7 +102,7 @@
               }
             }
           });
-          if (Object.keys(items).length) {
+          if (nbItems) {
             select.trigger("liszt:updated");
           } else {
             select.data().chosen.no_results_clear();

--- a/lib/ajax-chosen.min.js
+++ b/lib/ajax-chosen.min.js
@@ -7,11 +7,11 @@ $(this).data('prevVal',val);if(this.timer){clearTimeout(this.timer);}
 if(val.length<options.minTermLength){return false;}
 field=$(this);if(!(options.data!=null)){options.data={};}
 options.data[options.jsonTermKey]=val;if(options.dataCallback!=null){options.data=options.dataCallback(options.data);}
-success=options.success;options.success=function(data){var items,selected_values;if(!(data!=null)){return;}
-selected_values=[];select.find('option').each(function(){if(!$(this).is(":selected")){return $(this).remove();}else{return selected_values.push($(this).val()+"-"+$(this).text());}});select.find('optgroup:empty').each(function(){return $(this).remove();});items=callback(data);$.each(items,function(i,element){var group,text,value;if(element.group){group=select.find("optgroup[label='"+element.text+"']");if(!group.size()){group=$("<optgroup />");}
+success=options.success;options.success=function(data){var items,nbItems,selected_values;if(!(data!=null)){return;}
+selected_values=[];select.find('option').each(function(){if(!$(this).is(":selected")){return $(this).remove();}else{return selected_values.push($(this).val()+"-"+$(this).text());}});select.find('optgroup:empty').each(function(){return $(this).remove();});items=callback(data);nbItems=0;$.each(items,function(i,element){var group,text,value;nbItems++;if(element.group){group=select.find("optgroup[label='"+element.text+"']");if(!group.size()){group=$("<optgroup />");}
 group.attr('label',element.text).appendTo(select);return $.each(element.items,function(i,element){var text,value;if(typeof element==="string"){value=i;text=element;}else{value=element.value;text=element.text;}
 if($.inArray(value+"-"+text,selected_values)===-1){return $("<option />").attr('value',value).html(text).appendTo(group);}});}else{if(typeof element==="string"){value=i;text=element;}else{value=element.value;text=element.text;}
-if($.inArray(value+"-"+text,selected_values)===-1){return $("<option />").attr('value',value).html(text).appendTo(select);}}});if(Object.keys(items).length){select.trigger("liszt:updated");}else{select.data().chosen.no_results_clear();select.data().chosen.no_results(field.attr('value'));}
+if($.inArray(value+"-"+text,selected_values)===-1){return $("<option />").attr('value',value).html(text).appendTo(select);}}});if(nbItems){select.trigger("liszt:updated");}else{select.data().chosen.no_results_clear();select.data().chosen.no_results(field.attr('value'));}
 if(success!=null){success(data);}
 return field.attr('value',untrimmed_val);};return this.timer=setTimeout(function(){if(chosenXhr){chosenXhr.abort();}
 return chosenXhr=$.ajax(options);},options.afterTypeDelay);});});};})(jQuery);

--- a/src/ajax-chosen.coffee
+++ b/src/ajax-chosen.coffee
@@ -93,9 +93,14 @@ do ($ = jQuery) ->
             # value => text pairs to inject as <option> elements.
             items = callback data
             
+
+            nbItems = 0
+
             # Iterate through the given data and inject the <option> elements into
             # the DOM if it doesn't exist in the selector already
             $.each items, (i, element) ->
+              nbItems++
+
               if element.group
                 group = select.find("optgroup[label='#{element.text}']")
                 group = $("<optgroup />") unless group.size()
@@ -126,8 +131,8 @@ do ($ = jQuery) ->
                     .attr('value', value)
                     .html(text)
                     .appendTo(select)
-                
-            if Object.keys(items).length
+
+            if nbItems
               # Tell chosen that the contents of the <select> input have been updated
               # This makes chosen update its internal list of the input data.
               select.trigger("liszt:updated")


### PR DESCRIPTION
Commit [971a881](https://github.com/meltingice/ajax-chosen/commit/971a881f51d64b0db7fff82bb9dc561e1f671ce8) introduced a regression on Internet Explorer 7 & 8.

The Object.keys is not implemented on these browsers as described here: https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/Object/keys

I replaced this ECMAScript 5th Edition function by a more classic style. It's been tested on Internet Explorer.

Both Coffeescript & Javascript files have been modified, no need to compile.
