### PR TITLE
Typing fixes

### DIFF
--- a/src/ajax-chosen.coffee
+++ b/src/ajax-chosen.coffee
@@ -62,17 +62,19 @@ do ($ = jQuery) ->
           field = $(@)
           
           # Default term key is `term`.  Specify alternative in options.options.jsonTermKey
-          options.data = {} if not options.data?
-          options.data[options.jsonTermKey] = val
-          options.data = options.dataCallback(options.data) if options.dataCallback? 
+          # Create a copy of options so options.success doesn't get overwritten
+          ajaxOptions = $.extend({}, options)
+          ajaxOptions.data = {} if not ajaxOptions.data?
+          ajaxOptions.data[options.jsonTermKey] = val
+          ajaxOptions.data = ajaxOptions.dataCallback(ajaxOptions.data) if ajaxOptions.dataCallback? 
           
           # If the user provided an ajax success callback, store it so we can
           # call it after our bootstrapping is finished.
-          success = options.success
+          success = ajaxOptions.success
           
           # Create our own callback that will be executed when the ajax call is
           # finished.
-          options.success = (data) ->
+          ajaxOptions.success = (data) ->
             # Exit if the data we're given is invalid
             return if not data?
             
@@ -165,5 +167,5 @@ do ($ = jQuery) ->
           # Execute the ajax call to search for autocomplete data with a timer
           @timer = setTimeout -> 
             chosenXhr.abort() if chosenXhr
-            chosenXhr = $.ajax(options)
+            chosenXhr = $.ajax(ajaxOptions)
           , options.afterTypeDelay

--- a/src/ajax-chosen.coffee
+++ b/src/ajax-chosen.coffee
@@ -26,12 +26,19 @@ do ($ = jQuery) ->
       # our ajax autocomplete code.
       $(@).next('.chzn-container')
         .find(".search-field > input, .chzn-search > input")
+        .bind 'keydown', ->
+          field = $(@)
+          # The value is not immediately updated on keydown, so wait a couple milliseconds
+          # before looking it up
+          setTimeout ->
+            field.data('untrimmed_val', field.attr('value'))
+          , 1
         .bind 'keyup', ->
           # This code will be executed every time the user types a letter
           # into the input form that chosen has created
           
           # Retrieve the current value of the input form
-          untrimmed_val = $(@).attr('value')
+          
           val = $.trim $(@).attr('value')
 
           # Depending on how much text the user has typed, let them know
@@ -150,7 +157,7 @@ do ($ = jQuery) ->
             # call trigger above. Often, this can be very annoying (and can make some
             # searches impossible), so we add the value the user was typing back into
             # the input field.
-            field.attr('value', untrimmed_val)
+            field.attr('value', field.data('untrimmed_val'))
 
             # Because non-ajax Chosen isn't constantly re-building results, when it
             # DOES rebuild results (during liszt:updated above, it clears the input 


### PR DESCRIPTION
This addresses two problems:
1. Issue #30. Success callback is rebound on every keyup, causing a recursive call to itself. The success callback should now only be called once after a successful ajax call.
2. When chosen clears the text field after liszt:update, the repopulation of the field would sometimes use a stale value resulting in typed characters being lost.
