### PR TITLE
Corrected example JSON for grouped results

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ $("#example-input").ajaxChosen({
 	$.each(data, function (i, val) {
 		var group = { // here's a group object:
 			group: true,
-			text: val.name, // label for the group
+			text: val.text, // label for the group
 			items: [] // individual options within the group
 		};
 


### PR DESCRIPTION
The js code example for grouped results expects groups to have a 'name', not a 'text', as provided in the JSON example. I slipped up on this as I built my server-side code to feed JSON matching the example.
