### PR TITLE
add support for the `paste` event

### DIFF
--- a/src/ajax-chosen.coffee
+++ b/src/ajax-chosen.coffee
@@ -26,6 +26,13 @@ do ($ = jQuery) ->
       # our ajax autocomplete code.
       $(@).next('.chzn-container')
         .find(".search-field > input, .chzn-search > input")
+
+        .bind 'paste', ->
+          ajax_chosen = $(this)
+          paste_callback = ->
+            ajax_chosen.trigger('keyup')
+          setTimeout(paste_callback, 50)
+
         .bind 'keyup', ->
           # This code will be executed every time the user types a letter
           # into the input form that chosen has created


### PR DESCRIPTION
After a paste event, wait a short time (50ms for now) until the text is actually present in the text-box, then trigger `keyup` as if that text had just been typed.

This is meant to address #68.
