### PR TITLE
fixing disappearing input value

### DIFF
--- a/src/ajax-chosen.coffee
+++ b/src/ajax-chosen.coffee
@@ -149,6 +149,7 @@ do ($ = jQuery) ->
             # searches impossible), so we add the value the user was typing back into
             # the input field.
             field.val(untrimmed_val)
+            field.data('ajaxChosenValue', untrimmed_val)
 
             # Because non-ajax Chosen isn't constantly re-building results, when it
             # DOES rebuild results (during liszt:updated above, it clears the input
@@ -167,3 +168,6 @@ do ($ = jQuery) ->
             chosenXhr.abort() if chosenXhr
             chosenXhr = $.ajax(options)
           , options.afterTypeDelay
+        .bind 'ajaxStop', (data) -> 
+          $field = $(data.currentTarget)
+          $field.val($field.data('ajaxChosenValue'))


### PR DESCRIPTION
With jQuery 1.7.1 even though it is so old :) 
An ajaxStop event is called so i copy the current field value to data attribute then when the ajaxStop event finishes copy the data back from the data to the value.